### PR TITLE
Feat/회원수정 기능 구현 #21

### DIFF
--- a/src/main/java/com/PickOne/PickOneApplication.java
+++ b/src/main/java/com/PickOne/PickOneApplication.java
@@ -1,11 +1,15 @@
 package com.PickOne;
 
-import com.PickOne.domain.user.model.entity.Member;
+import com.PickOne.domain.user.model.Member;
 import com.PickOne.domain.user.repository.MemberRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
 
 @SpringBootApplication
 public class PickOneApplication {
@@ -15,6 +19,7 @@ public class PickOneApplication {
     }
 
     @Bean
+    @Profile("dev")
     public CommandLineRunner initTestUser(MemberRepository memberRepository) {
         return args -> {
             if (memberRepository.findByLoginId("testUser").isEmpty()) {

--- a/src/main/java/com/PickOne/domain/user/controller/MemberController.java
+++ b/src/main/java/com/PickOne/domain/user/controller/MemberController.java
@@ -35,5 +35,11 @@ public class MemberController {
         return BaseResponse.success(SuccessCode.OK, dto);
     }
 
+    @PutMapping("/{id}")
+    public ResponseEntity<BaseResponse<MemberResponseDto>> update(@PathVariable Long id,
+                                                                  @RequestBody MemberUpdateDto dto) {
+        MemberResponseDto updated = memberService.updateMember(id, dto);
+        return BaseResponse.success(SuccessCode.UPDATED);
+    }
 
 }

--- a/src/main/java/com/PickOne/domain/user/controller/MemberController.java
+++ b/src/main/java/com/PickOne/domain/user/controller/MemberController.java
@@ -35,11 +35,17 @@ public class MemberController {
         return BaseResponse.success(SuccessCode.OK, dto);
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<BaseResponse<MemberResponseDto>> update(@PathVariable Long id,
                                                                   @RequestBody MemberUpdateDto dto) {
         MemberResponseDto updated = memberService.updateMember(id, dto);
         return BaseResponse.success(SuccessCode.UPDATED);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
+        memberService.deleteMember(id);
+        return BaseResponse.success(SuccessCode.DELETED);
     }
 
 }

--- a/src/main/java/com/PickOne/domain/user/dto/MemberDto.java
+++ b/src/main/java/com/PickOne/domain/user/dto/MemberDto.java
@@ -1,0 +1,53 @@
+package com.PickOne.domain.user.dto;
+
+
+import com.PickOne.domain.user.model.Role;
+import lombok.NoArgsConstructor;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class MemberDto {
+
+    /**
+     * (1) Create DTO
+     */
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class MemberCreateDto {
+        private String loginId;
+        private String password;
+        private String username;
+        private String email;
+        private String nickname;
+    }
+
+    /**
+     * (2) Update DTO
+     */
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class MemberUpdateDto {
+        private String username;
+        private String nickname;
+    }
+
+    /**
+     * (3) Response DTO
+     */
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class MemberResponseDto {
+        private Long id;
+        private String loginId;
+        private String username;
+        private String email;
+        private String nickname;
+        private Role role;
+    }
+
+}

--- a/src/main/java/com/PickOne/domain/user/service/MemberService.java
+++ b/src/main/java/com/PickOne/domain/user/service/MemberService.java
@@ -76,10 +76,20 @@ public class MemberService {
                 && memberRepository.existsByNickname(dto.getNickname())) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
-
-        member.setUsername(dto.getUsername());
-        member.setNickname(dto.getNickname());
+        if(member.getUsername() != null ){
+            member.setUsername(dto.getUsername());
+        }
+        if(member.getNickname() != null) {
+            member.setNickname(dto.getNickname());
+        }
         return modelMapper.map(member, MemberResponseDto.class);
+    }
+
+
+    public void deleteMember(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INFO_NOT_FOUND));
+        memberRepository.delete(member);
     }
 }
 

--- a/src/main/java/com/PickOne/domain/user/service/MemberService.java
+++ b/src/main/java/com/PickOne/domain/user/service/MemberService.java
@@ -64,4 +64,22 @@ public class MemberService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_INFO_NOT_FOUND));
         return modelMapper.map(member, MemberResponseDto.class);
     }
+
+
+    @Transactional
+    public MemberResponseDto updateMember(Long id, MemberUpdateDto dto) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INFO_NOT_FOUND));
+
+        // 닉네임 중복
+        if (!member.getNickname().equals(dto.getNickname())
+                && memberRepository.existsByNickname(dto.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        member.setUsername(dto.getUsername());
+        member.setNickname(dto.getNickname());
+        return modelMapper.map(member, MemberResponseDto.class);
+    }
 }
+

--- a/src/main/java/com/PickOne/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/PickOne/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.PickOne.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/com/PickOne/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/PickOne/domain/user/controller/MemberControllerTest.java
@@ -1,16 +1,19 @@
 package com.PickOne.domain.user.controller;
 
+import com.PickOne.PickOneApplication;
 import com.PickOne.domain.user.dto.MemberDto.*;
-import com.PickOne.domain.user.repository.MemberRepository;
 import com.PickOne.domain.user.service.MemberService;
+import com.PickOne.global.exception.BusinessException;
+import com.PickOne.global.exception.ErrorCode;
 import com.PickOne.global.exception.SuccessCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,36 +21,49 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-@SpringBootTest
-@AutoConfigureMockMvc(addFilters = false)
+/**
+ * @WebMvcTest
+ *  - Controller 계층만 로딩하여 테스트하는 슬라이스 테스트.
+ *  - Service, Repository 등 다른 Bean들은 기본적으로 로드되지 않음.
+ */
+@WebMvcTest(
+        controllers = MemberController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = PickOneApplication.class // ★ 메인 클래스 제외 ★
+                )
+        },
+        excludeAutoConfiguration = {
+                // JPA 관련 자동설정 빼기
+                org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        }
+)
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 등 필터 꺼두기(필요 시)
 class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
+    /**
+     * Controller가 주입받는 Service를 MockBean으로 등록
+     */
     @MockBean
     private MemberService memberService;
 
-    @MockBean
-    private MemberRepository memberRepository;
 
     @Test
-    @DisplayName("회원 가입 테스트")
+    @DisplayName("회원 가입 테스트 - 성공")
     void signUpTest() throws Exception {
         // given
-        MemberCreateDto createDto = new MemberCreateDto();
-        createDto.setLoginId("testUser");
-        createDto.setPassword("testPass");
-        createDto.setUsername("유저");
-        createDto.setEmail("user@test.com");
-        createDto.setNickname("닉네임");
-
-        doNothing().when(memberService).createMember(any(MemberCreateDto.class));
+        // "회원 생성" 로직은 아무 일도 일어나지 않는다고 가정
+        willDoNothing().given(memberService).createMember(any(MemberCreateDto.class));
 
         // when & then
         mockMvc.perform(post("/api/members")
@@ -61,11 +77,11 @@ class MemberControllerTest {
                                   "nickname": "닉네임"
                                 }
                                 """))
-                .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.message").value(SuccessCode.CREATED.getMessage()));
     }
+
 
     @Test
     @DisplayName("전체 회원 조회 테스트")
@@ -86,22 +102,23 @@ class MemberControllerTest {
         dto2.setNickname("닉네임2");
 
         List<MemberResponseDto> responseList = Arrays.asList(dto1, dto2);
-        when(memberService.getAllMembers()).thenReturn(responseList);
+
+        // Service에서 getAllMembers() 호출 시, 위 responseList를 반환한다고 Mock
+        given(memberService.getAllMembers()).willReturn(responseList);
 
         // when & then
         mockMvc.perform(get("/api/members")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.message").value(SuccessCode.OK.getMessage()))
-                .andExpect(jsonPath("$.result").isArray())
                 .andExpect(jsonPath("$.result[0].username").value("유저1"))
                 .andExpect(jsonPath("$.result[1].username").value("유저2"));
     }
 
+
     @Test
-    @DisplayName("단일 회원 조회 테스트")
+    @DisplayName("단일 회원 조회 테스트 - 성공")
     void getOneTest() throws Exception {
         // given
         MemberResponseDto dto = new MemberResponseDto();
@@ -111,12 +128,12 @@ class MemberControllerTest {
         dto.setEmail("user1@test.com");
         dto.setNickname("닉네임1");
 
-        when(memberService.getMember(1L)).thenReturn(dto);
+        // Service 호출 시 dto 반환
+        given(memberService.getMember(1L)).willReturn(dto);
 
         // when & then
         mockMvc.perform(get("/api/members/1")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.message").value(SuccessCode.OK.getMessage()))
@@ -124,5 +141,79 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.result.email").value("user1@test.com"));
     }
 
+
+    @Test
+    @DisplayName("회원 정보 업데이트 성공 테스트")
+    void updateMember_Success() throws Exception {
+        // given
+        // 업데이트가 성공적으로 진행되었다고 가정
+        MemberResponseDto updatedDto = new MemberResponseDto();
+        updatedDto.setId(1L);
+        updatedDto.setUsername("업데이트유저");
+        updatedDto.setNickname("업데이트닉네임");
+
+        // Service가 성공적으로 업데이트된 결과를 리턴한다고 Mock
+        given(memberService.updateMember(eq(1L), any(MemberUpdateDto.class)))
+                .willReturn(updatedDto);
+
+        // when & then
+        mockMvc.perform(put("/api/members/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "업데이트유저",
+                                  "nickname": "업데이트닉네임"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value(SuccessCode.UPDATED.getMessage()));
+    }
+
+
+    @Test
+    @DisplayName("회원 정보 업데이트 실패 - 닉네임 중복")
+    void updateMember_DuplicateNickname() throws Exception {
+        // given
+        // 닉네임 중복 시 발생하는 예외를 던지도록 Mock
+        willThrow(new BusinessException(ErrorCode.DUPLICATE_NICKNAME))
+                .given(memberService).updateMember(eq(1L), any(MemberUpdateDto.class));
+
+        // when & then
+        mockMvc.perform(put("/api/members/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "업데이트유저",
+                                  "nickname": "중복닉네임"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.DUPLICATE_NICKNAME.getMessage()));
+    }
+
+
+    @Test
+    @DisplayName("회원 정보 업데이트 실패 - 회원 없음(404)")
+    void updateMember_NotFound() throws Exception {
+        // given
+        // 존재하지 않는 회원 ID 요청 시 발생하는 예외를 던지도록 Mock
+        willThrow(new BusinessException(ErrorCode.USER_INFO_NOT_FOUND))
+                .given(memberService).updateMember(eq(999L), any(MemberUpdateDto.class));
+
+        // when & then
+        mockMvc.perform(put("/api/members/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "업데이트유저",
+                                  "nickname": "업데이트닉네임"
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.USER_INFO_NOT_FOUND.getMessage()));
+    }
 
 }

--- a/src/test/java/com/PickOne/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/com/PickOne/domain/user/controller/MemberControllerTest.java
@@ -157,7 +157,7 @@ class MemberControllerTest {
                 .willReturn(updatedDto);
 
         // when & then
-        mockMvc.perform(put("/api/members/1")
+        mockMvc.perform(patch("/api/members/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -180,7 +180,7 @@ class MemberControllerTest {
                 .given(memberService).updateMember(eq(1L), any(MemberUpdateDto.class));
 
         // when & then
-        mockMvc.perform(put("/api/members/1")
+        mockMvc.perform(patch("/api/members/1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
@@ -203,7 +203,7 @@ class MemberControllerTest {
                 .given(memberService).updateMember(eq(999L), any(MemberUpdateDto.class));
 
         // when & then
-        mockMvc.perform(put("/api/members/999")
+        mockMvc.perform(patch("/api/members/999")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {

--- a/src/test/java/com/PickOne/domain/user/service/MemberServiceTest.java
+++ b/src/test/java/com/PickOne/domain/user/service/MemberServiceTest.java
@@ -156,5 +156,83 @@ class MemberServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.USER_INFO_NOT_FOUND.getMessage());
     }
+
+    @Test
+    @DisplayName("회원 정보 업데이트 성공 테스트")
+    void updateMember_Success() {
+        // given
+        Long memberId = 1L;
+        Member member = Member.builder()
+                .loginId("user1")
+                .password("password")
+                .username("기존유저")
+                .nickname("기존닉네임")
+                .email("user1@test.com")
+                .build();
+        memberRepository.save(member);
+
+        MemberUpdateDto updateDto = new MemberUpdateDto();
+        updateDto.setUsername("업데이트유저");
+        updateDto.setNickname("업데이트닉네임");
+
+        // when
+        MemberResponseDto result = memberService.updateMember(member.getId(), updateDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isEqualTo("업데이트유저");
+        assertThat(result.getNickname()).isEqualTo("업데이트닉네임");
+
+        Member updatedMember = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(updatedMember.getUsername()).isEqualTo("업데이트유저");
+        assertThat(updatedMember.getNickname()).isEqualTo("업데이트닉네임");
+    }
+
+    @Test
+    @DisplayName("회원 정보 업데이트 실패 - 닉네임 중복")
+    void updateMember_DuplicateNickname() {
+        // given
+        Member member1 = Member.builder()
+                .loginId("user1")
+                .password("password")
+                .username("유저1")
+                .nickname("닉네임1")
+                .email("user1@test.com")
+                .build();
+        memberRepository.save(member1);
+
+        Member member2 = Member.builder()
+                .loginId("user2")
+                .password("password")
+                .username("유저2")
+                .nickname("닉네임2")
+                .email("user2@test.com")
+                .build();
+        memberRepository.save(member2);
+
+        MemberUpdateDto updateDto = new MemberUpdateDto();
+        updateDto.setUsername("유저1-업데이트");
+        updateDto.setNickname("닉네임2");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateMember(member1.getId(), updateDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.DUPLICATE_NICKNAME.getMessage());
+    }
+
+    @Test
+    @DisplayName("회원 정보 업데이트 실패 - 회원 없음")
+    void updateMember_NotFound() {
+        // given
+        Long invalidId = 999L;
+        MemberUpdateDto updateDto = new MemberUpdateDto();
+        updateDto.setUsername("유저1-업데이트");
+        updateDto.setNickname("닉네임1");
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateMember(invalidId, updateDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_INFO_NOT_FOUND.getMessage());
+    }
 }
 


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 회원 수정 기능, JPA Auditing 설정을 JpaAuditingConfig 클래스로 분리,
개발 환경에서만 활성화되도록 @Profile("dev")를 적용.
리뷰에서 제안된 변경 사항 반영.

> ## #️⃣연관된 이슈

> #24 

## 💡 리뷰어에게 하고 싶은 말
- [x] 회원 수정 기능의 비즈니스 로직과 API 설계가 적절한지 확인
- [x] 리뷰에서 제안된 변경 사항이 잘 반영되었는지 확인 

<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
