### PR TITLE
Feat/약관생성 기능 구현 #27

### DIFF
--- a/src/main/java/com/PickOne/domain/user/controller/TermController.java
+++ b/src/main/java/com/PickOne/domain/user/controller/TermController.java
@@ -1,0 +1,28 @@
+package com.PickOne.domain.user.controller;
+
+import com.PickOne.domain.user.dto.TermDto.*;
+import com.PickOne.domain.user.service.TermService;
+import com.PickOne.global.exception.BaseResponse;
+import com.PickOne.global.exception.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/terms")
+@RequiredArgsConstructor
+public class TermController {
+
+    private final TermService termService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> createTerm(@Valid @RequestBody TermCreateDto dto) {
+        termService.createTerm(dto);
+        return BaseResponse.success(SuccessCode.CREATED);
+    }
+
+
+}

--- a/src/main/java/com/PickOne/domain/user/dto/TermDto.java
+++ b/src/main/java/com/PickOne/domain/user/dto/TermDto.java
@@ -1,0 +1,46 @@
+package com.PickOne.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+public class TermDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TermCreateDto {
+
+        @NotBlank
+        @Size(max = 255)
+        private String title;
+
+        @NotBlank
+        private String content;
+
+        @NotNull
+        @Size(min = 1, max = 10)
+        private String version;
+
+        @NotNull
+        private Boolean isRequired; // 필수 여부
+
+        @NotNull
+        private Boolean isActive; // 활성 여부
+
+        @NotNull
+        private LocalDate startDate;
+
+        private LocalDate endDate; // 무기한 유효, 종료 날짜가 정해지지 않았을 때 null
+
+    }
+
+
+}
+
+

--- a/src/main/java/com/PickOne/domain/user/model/Term.java
+++ b/src/main/java/com/PickOne/domain/user/model/Term.java
@@ -2,7 +2,9 @@ package com.PickOne.domain.user.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
@@ -34,6 +36,14 @@ public class Term extends BaseTimeEntity {
     @Column(name = "is_active", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean isActive;
 
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
     @OneToMany(mappedBy = "term", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<MemberTerm> memberTerms;
+
+    //약관 이력 TermHistory
 }

--- a/src/main/java/com/PickOne/domain/user/repository/TermRepository.java
+++ b/src/main/java/com/PickOne/domain/user/repository/TermRepository.java
@@ -6,12 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
-
-    // 필수 + 활성인 약관 목록
-    List<Term> findByIsRequiredTrueAndIsActiveTrue();
-
     // 약관 버전 중복 확인
-    boolean existsByVersion(String version); //
+    boolean existsByTitleAndVersion(String title, String version); //
 }

--- a/src/main/java/com/PickOne/domain/user/service/TermService.java
+++ b/src/main/java/com/PickOne/domain/user/service/TermService.java
@@ -1,0 +1,45 @@
+package com.PickOne.domain.user.service;
+
+import com.PickOne.domain.user.dto.TermDto.*;
+import com.PickOne.domain.user.model.Term;
+import com.PickOne.domain.user.repository.TermRepository;
+import com.PickOne.global.exception.BusinessException;
+import com.PickOne.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TermService {
+
+    private final TermRepository termRepository;
+    private final ModelMapper modelMapper;
+
+    public void createTerm(TermCreateDto dto) {
+        // 제목과 버전 중복 체크
+        if (termRepository.existsByTitleAndVersion(dto.getTitle(), dto.getVersion())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_TERM_VERSION);
+        }
+
+        Term term = Term.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .version(dto.getVersion())
+                .isRequired(dto.getIsRequired())
+                .isActive(dto.getIsActive())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .build();
+
+        termRepository.save(term);
+    }
+
+}

--- a/src/test/java/com/PickOne/domain/user/controller/TermControllerTest.java
+++ b/src/test/java/com/PickOne/domain/user/controller/TermControllerTest.java
@@ -1,0 +1,74 @@
+package com.PickOne.domain.user.controller;
+
+import com.PickOne.PickOneApplication;
+import com.PickOne.domain.user.dto.TermDto.*;
+import com.PickOne.domain.user.service.TermService;
+import com.PickOne.domain.user.controller.TermController;
+import com.PickOne.global.exception.BusinessException;
+import com.PickOne.global.exception.ErrorCode;
+import com.PickOne.global.exception.SuccessCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = TermController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = PickOneApplication.class
+                )
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+class TermControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TermService termService;
+
+    @Test
+    @DisplayName("약관 생성 테스트 - 성공")
+    void 약관_생성_테스트_성공() throws Exception {
+        // given
+        willDoNothing().given(termService).createTerm(any(TermCreateDto.class));
+
+        // when & then
+        mockMvc.perform(post("/api/terms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title": "약관 제목",
+                                  "content": "약관 내용",
+                                  "version": "1.0",
+                                  "isRequired": true,
+                                  "isActive": true,
+                                  "startDate": "2023-01-01",
+                                  "endDate": "2023-12-31"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value(SuccessCode.CREATED.getMessage()))
+                .andExpect(jsonPath("$.result").doesNotExist());
+    }
+
+}

--- a/src/test/java/com/PickOne/domain/user/service/TermServiceTest.java
+++ b/src/test/java/com/PickOne/domain/user/service/TermServiceTest.java
@@ -1,0 +1,77 @@
+package com.PickOne.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.PickOne.domain.user.dto.TermDto.*;
+import com.PickOne.domain.user.model.Term;
+import com.PickOne.domain.user.repository.TermRepository;
+import com.PickOne.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+
+import java.time.LocalDate;
+
+class TermServiceTest {
+
+    @Mock
+    private TermRepository termRepository;
+
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private TermService termService;
+
+    @BeforeEach
+    void 설정() {
+        MockitoAnnotations.openMocks(this);
+        modelMapper = new ModelMapper(); // 실제 ModelMapper 사용
+        termService = new TermService(termRepository, modelMapper); // Service에 ModelMapper 주입
+    }
+
+    @Test
+    void 제목과_버전이_중복되면_예외를_던진다() {
+        // Given
+        TermCreateDto dto = new TermCreateDto();
+        dto.setTitle("테스트 제목");
+        dto.setVersion("1.0");
+        dto.setContent("테스트 내용");
+        dto.setIsRequired(true);
+        dto.setIsActive(true);
+        dto.setStartDate(LocalDate.now());
+        dto.setEndDate(LocalDate.now().plusDays(10));
+
+        when(termRepository.existsByTitleAndVersion(dto.getTitle(), dto.getVersion())).thenReturn(true);
+
+        // When & Then
+        assertThrows(BusinessException.class, () -> termService.createTerm(dto));
+        verify(termRepository, times(1)).existsByTitleAndVersion(dto.getTitle(), dto.getVersion());
+        verify(termRepository, never()).save(any(Term.class));
+    }
+
+    @Test
+    void 제목과_버전이_중복되지_않으면_저장한다() {
+        // Given
+        TermCreateDto dto = new TermCreateDto();
+        dto.setTitle("테스트 제목");
+        dto.setVersion("1.0");
+        dto.setContent("테스트 내용");
+        dto.setIsRequired(true);
+        dto.setIsActive(true);
+        dto.setStartDate(LocalDate.now());
+        dto.setEndDate(LocalDate.now().plusDays(10));
+
+        when(termRepository.existsByTitleAndVersion(dto.getTitle(), dto.getVersion())).thenReturn(false);
+
+        // When
+        termService.createTerm(dto);
+
+        // Then
+        verify(termRepository, times(1)).existsByTitleAndVersion(dto.getTitle(), dto.getVersion());
+        verify(termRepository, times(1)).save(any(Term.class));
+    }
+}


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 약관 생성 기능입니다.

약관 생성 시 유효기간(startDate, endDate)을 입력받아 처리
DTO, 엔티티, 서비스, 컨트롤러 계층에 약관 생성 관련 로직을 추가

> ## #️⃣연관된 이슈

> #27 

## 💡 리뷰어에게 하고 싶은 말
- [x] 유효기간(startDate, endDate) 추가

<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
